### PR TITLE
Add Knots specifc seeds

### DIFF
--- a/conf/crawl.conf.default
+++ b/conf/crawl.conf.default
@@ -15,6 +15,8 @@ db = 0
 # List of DNS seeders to get a subset of reachable nodes
 seeders =
     seed.bitcoin.sipa.be
+    dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us
+    seed.bitcoin.haf.ovh
     dnsseed.bluematt.me
     seed.bitcoin.jonasschnelli.ch
     seed.btc.petertodd.net


### PR DESCRIPTION
Since Bitcoin Knots now represent +20% of the nodes of the Bitcoin Network it would be a good idea to track Knots specific seeds.