### PR TITLE
Fix include_asns excluding all peers when unset

### DIFF
--- a/crawl.py
+++ b/crawl.py
@@ -605,6 +605,9 @@ def is_excluded(address):
     if asn in exclude_asns:
         return True
 
+    if include_asns and asn not in include_asns:
+        return True
+
     if ":" in address:
         address_family = socket.AF_INET6
         exclude_ip_networks = CONF["current_exclude_ipv6_networks"]
@@ -617,9 +620,6 @@ def is_excluded(address):
         logging.warning("Bad address: %s", address)
         return True
     if any([(addr & net[1] == net[0]) for net in exclude_ip_networks]):
-        return True
-
-    if asn not in include_asns:
         return True
 
     return False


### PR DESCRIPTION
Fix regression added in e0209579d132957e5501733214ba976c508743c4 crawl.py L548 where using the default config with current_include_asns unset make is_exclude() return True for all addresses so all addresses were excluded leaving none left to crawl.